### PR TITLE
fix(traefik): re-enable kubernetesCRD provider for Gateway API middlewares

### DIFF
--- a/kubernetes/apps/network/traefik/app/helm-release.yaml
+++ b/kubernetes/apps/network/traefik/app/helm-release.yaml
@@ -16,7 +16,7 @@ spec:
   values: # https://github.com/traefik/traefik-helm-chart/blob/master/traefik/VALUES.md#values
     providers:
       kubernetesCRD:
-        enabled: false
+        allowCrossNamespace: true  # needed for ForwardAuth and network-*@kubernetescrd chains
       kubernetesGateway:
         enabled: true
     resources:


### PR DESCRIPTION
Disabling kubernetesCRD when deprecating the traefik-crds chart broke HTTPRoute ExtensionRef filters (traefik.io/Middleware). The kubernetesGateway provider only routes via Gateway API; Middleware ExtensionRef and @kubernetescrd chain references still require kubernetesCRD.

Re-enable allowCrossNamespace for per-namespace auth-chain middlewares that reference network-secure-headers, network-forwardauth-authelia, and network-compress in the network namespace.