### PR TITLE
Feature: Habitica

### DIFF
--- a/kubernetes/apps/default/habitica/app/helm-release.yaml
+++ b/kubernetes/apps/default/habitica/app/helm-release.yaml
@@ -1,0 +1,152 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/app-template-5.0.1/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: habitica
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+    namespace: flux-system
+  interval: 30m
+  values:
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
+    controllers:
+      habitica:
+        # annotations:
+        #   reloader.stakater.com/auto: "true"
+        containers:
+          habitica:
+            image:
+              repository: docker.io/awinterstein/habitica-server
+              tag: 5.48.0@sha256:c3732b25863f0d0a8f0b11e7cc147a4b7226fe966e4bc3feb426e07a3e256f51
+            env:
+              TZ: ${TIME_ZONE}
+              NODE_DB_URI: mongodb://habitica-mongodb/habitica
+              BASE_URL: http://127.0.0.1:3000
+              INVITE_ONLY: true
+              EMAIL_SERVER_URL: maddy.default.svc.cluster.local
+              EMAIL_SERVER_PORT: 2525
+              ADMIN_EMAIL: noreply@mail.${CLUSTER_DOMAIN}
+            probes:
+              liveness: &probe
+                enabled: true
+              readiness: *probe
+            # resources:
+            #   requests:
+            #     cpu: 25m
+            #     memory: 64Mi
+            #   limits:
+            #     memory: 256Mi
+            securityContext:
+              runAsUser: 65534
+              runAsGroup: 65534
+              # allowPrivilegeEscalation: false
+              # readOnlyRootFilesystem: true
+              # capabilities:
+              #   drop:
+              #     - ALL
+      mongodb:
+        # annotations:
+        #   reloader.stakater.com/auto: "true"
+        pod:
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: kubernetes.io/hostname
+                        operator: NotIn
+                        values: ["raspberrypi"]
+          securityContext:
+            runAsUser: 7002
+            runAsGroup: 7002
+            fsGroup: 7002
+        containers:
+          mongodb:
+            image:
+              repository: docker.io/library/mongo
+              tag: 6.0.4@sha256:4b5bf3c2bb7516164f6dcb44acce4fdcb428abfe5771a1128304a0f34ab9ff7c
+            env:
+              TZ: ${TIME_ZONE}
+            resources:
+              requests:
+                cpu: 50m
+                memory: 64Mi
+              limits:
+                memory: 128Mi
+            # probes:
+            #   liveness: &probe
+            #     enabled: true
+            #     custom: true
+            #     spec:
+            #       exec:
+            #         command:
+            #           - mongosh
+            #           - --quiet
+            #           - --eval
+            #           - db.adminCommand('ping')
+            #   readiness: *probe
+            securityContext: {}
+              # allowPrivilegeEscalation: false
+              # readOnlyRootFilesystem: true
+              # capabilities:
+              #   drop:
+              #     - ALL
+    persistence:
+      mongodb-data:
+        type: persistentVolumeClaim
+        accessMode: ReadWriteOnce
+        size: 1Gi
+        advancedMounts:
+          mongodb:
+            mongodb:
+              - path: /data
+      # habitica-tmp:
+      #   type: emptyDir
+      #   advancedMounts:
+      #     habitica:
+      #       habitica:
+      #         - path: /tmp
+      # mongodb-tmp:
+      #   type: emptyDir
+      #   advancedMounts:
+      #     mongodb:
+      #       mongodb:
+      #         - path: /tmp
+    service:
+      habitica:
+        controller: habitica
+        ports:
+          http:
+            port: 3000
+            protocol: HTTP
+      mongodb:
+        controller: mongodb
+        ports:
+          mongodb:
+            port: 27017
+    route:
+      habitica:
+        annotations:
+          gethomepage.dev/enabled: "true"
+          gethomepage.dev/name: Habitica
+          gethomepage.dev/icon: habitica
+          gethomepage.dev/description: Habit tracker app which treats your goals like an RPG
+          gethomepage.dev/group: Apps
+          gethomepage.dev/pod-selector: app.kubernetes.io/name = habitica
+        hostnames:
+          - habitica.${CLUSTER_DOMAIN}
+        rules:
+          - backendRefs:
+              - identifier: habitica
+        parentRefs:
+          - name: traefik-gateway
+            namespace: network
+            sectionName: websecure

--- a/kubernetes/apps/default/habitica/app/helm-release.yaml
+++ b/kubernetes/apps/default/habitica/app/helm-release.yaml
@@ -19,6 +19,10 @@ spec:
           type: RuntimeDefault
     controllers:
       habitica:
+        strategy: RollingUpdate
+        rollingUpdate:
+          maxSurge: 1
+          maxUnavailable: 0
         # annotations:
         #   reloader.stakater.com/auto: "true"
         containers:
@@ -29,7 +33,7 @@ spec:
             env:
               TZ: ${TIME_ZONE}
               NODE_DB_URI: mongodb://habitica-mongodb/habitica
-              BASE_URL: http://127.0.0.1:3000
+              BASE_URL: https://habitica.${CLUSTER_DOMAIN}
               INVITE_ONLY: true
               EMAIL_SERVER_URL: maddy.default.svc.cluster.local
               EMAIL_SERVER_PORT: 2525
@@ -37,6 +41,11 @@ spec:
             probes:
               liveness: &probe
                 enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    port: &habiticaPort 3000
+                    path: /api/v3/status
               readiness: *probe
             # resources:
             #   requests:
@@ -53,6 +62,7 @@ spec:
               #   drop:
               #     - ALL
       mongodb:
+        type: statefulset
         # annotations:
         #   reloader.stakater.com/auto: "true"
         pod:
@@ -73,14 +83,16 @@ spec:
             image:
               repository: docker.io/library/mongo
               tag: 6.0.4@sha256:4b5bf3c2bb7516164f6dcb44acce4fdcb428abfe5771a1128304a0f34ab9ff7c
+            args:
+              - "--wiredTigerCacheSizeGB=0.125"
             env:
               TZ: ${TIME_ZONE}
-            resources:
-              requests:
-                cpu: 50m
-                memory: 64Mi
-              limits:
-                memory: 128Mi
+            # resources:
+            #   requests:
+            #     cpu: 50m
+            #     memory: 64Mi
+            #   limits:
+            #     memory: 128Mi
             # probes:
             #   liveness: &probe
             #     enabled: true
@@ -125,13 +137,13 @@ spec:
         controller: habitica
         ports:
           http:
-            port: 3000
+            port: *habiticaPort
             protocol: HTTP
       mongodb:
         controller: mongodb
         ports:
           mongodb:
-            port: 27017
+            port: &mongoDbPort 27017
     route:
       habitica:
         annotations:
@@ -150,3 +162,18 @@ spec:
           - name: traefik-gateway
             namespace: network
             sectionName: websecure
+    networkpolicies:
+      mongodb:
+        controller: mongodb
+        policyTypes:
+          - Ingress
+        rules:
+          ingress:
+            - from:
+                - podSelector:
+                    matchLabels:
+                      app.kubernetes.io/controller: habitica
+                      app.kubernetes.io/instance: "{{ .Release.Name }}"
+                      app.kubernetes.io/name: habitica
+              ports:
+                - port: *mongoDbPort

--- a/kubernetes/apps/default/habitica/app/kustomization.yaml
+++ b/kubernetes/apps/default/habitica/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helm-release.yaml

--- a/kubernetes/apps/default/habitica/ks.yaml
+++ b/kubernetes/apps/default/habitica/ks.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: habitica
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: external-secrets
+    - name: gateway-api-crds
+  path: /kubernetes/apps/default/habitica/app
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  targetNamespace: default
+  interval: 30m
+  timeout: 5m
+  wait: true
+  prune: true

--- a/kubernetes/apps/default/kustomization.yaml
+++ b/kubernetes/apps/default/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - ./namespace.yaml
   # Apps
   - ./garage/ks.yaml
+  - ./habitica/ks.yaml
   - ./homepage/ks.yaml
   - ./immich/ks.yaml
   - ./maddy/ks.yaml


### PR DESCRIPTION
# Habitica

I want to deploy Habitica, a habit-tracking app. It requires a MongoDB backend.

## Docs

Source: https://github.com/HabitRPG/habitica
Self host fork: https://github.com/awinterstein/habitica

## MongoDB

I did some research into using an operator for this, but found that the community version doesn't handle backup/restore... And I don't need scaling for this, so... It's sad how closed source MongoDB got. Just a standalone instance will do for this. I considered FerretDB, but I'm worried Habitica might actually use some more esoteric MongoDB features.